### PR TITLE
Enable the iframe sandbox

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelogs
 
+### Spotify Module v1.0.2 (Private Community Edition)
+- Enh: Enable the iframe sandbox
+- 
 ### Spotify Module v1.0.1 (Jan 03, 2022)
 - Fix: Text Typo
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Spotify Module v1.0.2 (Private Community Edition)
 - Enh: Enable the iframe sandbox
-- 
+
 ### Spotify Module v1.0.1 (Jan 03, 2022)
 - Fix: Text Typo
 

--- a/widgets/views/spotifyframe.php
+++ b/widgets/views/spotifyframe.php
@@ -13,7 +13,7 @@ use humhub\widgets\PanelMenu;
   <div class="panel-body">
 
 <?= Html::beginTag('div') ?>
-<iframe src="<?= $spotify; ?>" <?= Html::nonce() ?> width="100%" height="380" frameborder="0" allowtransparency="true" allow="encrypted-media" sandbox="allow-same-origin allow-scripts"></iframe>
+<iframe src="<?= $spotify; ?>" <?= Html::nonce() ?> width="100%" height="380" frameborder="0" allowtransparency="true" allow="encrypted-media" sandbox="allow-same-origin allow-scripts allow-popups"></iframe>
 <?= Html::endTag('div'); ?>
 </div>
 </div>

--- a/widgets/views/spotifyframe.php
+++ b/widgets/views/spotifyframe.php
@@ -13,7 +13,7 @@ use humhub\widgets\PanelMenu;
   <div class="panel-body">
 
 <?= Html::beginTag('div') ?>
-<iframe src="<?= $spotify; ?>" <?= Html::nonce() ?> width="100%" height="380" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
+<iframe src="<?= $spotify; ?>" <?= Html::nonce() ?> width="100%" height="380" frameborder="0" allowtransparency="true" allow="encrypted-media" sandbox="allow-same-origin allow-scripts"></iframe>
 <?= Html::endTag('div'); ?>
 </div>
 </div>


### PR DESCRIPTION
Enable the iframe sandbox to stronger isolate the embed iframe from the surrounding page and it's content. 
https://www.html5rocks.com/en/tutorials/security/sandboxed-iframes/ is a basic explanation of the sandbox.

As HumHub allows to create private communities, which might touch on very sensitive or personal topics, embedded carry the risk of information leakage or tracking of users and content. Isolating the embed/ iframe as strongly as possible should be the standard measure to ensure this boundary.

Successfully tested on Brave (Chromium engine) and Firefox - both on Linux, wider testing with more Browsers should be considered.